### PR TITLE
build: restore <scope>provided</scope> on Clojure + CLJS deps (rf2-6i657)

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -6,7 +6,8 @@
     clojure -T:build jar
     clojure -T:build install
     clojure -T:build deploy   ; needs CLOJARS_USERNAME + CLOJARS_PASSWORD"
-  (:require [clojure.tools.build.api :as b]
+  (:require [clojure.string :as str]
+            [clojure.tools.build.api :as b]
             [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'day8/de-dupe)
@@ -16,6 +17,32 @@
 
 (defn- basis []
   (b/create-basis {:project "deps.edn"}))
+
+(defn- inject-provided-scope
+  "Post-process the emitted pom.xml to add <scope>provided</scope> to the
+   org.clojure/clojure and org.clojure/clojurescript dependency entries.
+
+   tools.build's write-pom (as of v0.10.13) ignores :mvn/scope in deps.edn —
+   only :exclusions and :optional are honored. This restores the provided-scope
+   semantics the legacy project.clj had on these deps, so consumers don't
+   transitively pull a specific Clojure/CLJS version from this library."
+  [pom-path]
+  (let [pom (slurp pom-path)
+        ;; Match a <dependency> block whose groupId/artifactId is one of the
+        ;; targets, then inject <scope>provided</scope> before </dependency>.
+        ;; The block has no existing <scope> tag (tools.build doesn't emit one),
+        ;; so we simply insert before the closing tag.
+        target-artifacts #{"clojure" "clojurescript"}
+        dep-re #"(?s)(    <dependency>\s+<groupId>org\.clojure</groupId>\s+<artifactId>([^<]+)</artifactId>\s+<version>[^<]+</version>\s+)(</dependency>)"
+        pom' (str/replace pom dep-re
+                          (fn [[_ head artifact tail]]
+                            (if (target-artifacts artifact)
+                              (str head "  <scope>provided</scope>\n    " tail)
+                              (str head tail))))]
+    (when (= pom pom')
+      (throw (ex-info "inject-provided-scope: no Clojure/CLJS deps matched — pom format may have changed"
+                      {:pom-path pom-path})))
+    (spit pom-path pom')))
 
 (defn clean [_]
   (b/delete {:path "target"}))
@@ -36,6 +63,9 @@
                               [:name "MIT License"]
                               [:url "https://github.com/day8/de-dupe/blob/main/licence.txt"]
                               [:distribution "repo"]]]]})
+  ;; tools.build write-pom drops :mvn/scope — restore <scope>provided</scope>
+  ;; on the Clojure + CLJS deps before the jar is built.
+  (inject-provided-scope (b/pom-path {:lib lib :class-dir class-dir}))
   (b/copy-dir {:src-dirs   ["src"]
                :target-dir class-dir})
   (b/jar {:class-dir class-dir


### PR DESCRIPTION
## Summary

After the lein → tools.build swap (rf2-ucbuz), the emitted `pom.xml` listed `org.clojure/clojure` and `org.clojure/clojurescript` as ordinary (non-`provided`) dependencies. The legacy `project.clj` had `:scope \"provided\"` on these so consumers wouldn't transitively pull a specific Clojure/CLJS version.

Root cause: `clojure.tools.build.tasks.write-pom/to-dep` (as of v0.10.13) only honors `:exclusions` and `:optional` — it silently drops `:mvn/scope`. So adding `:mvn/scope \"provided\"` to `deps.edn` wouldn't help.

## Fix

Post-process the emitted `pom.xml` in `build.clj`'s `jar` fn between `write-pom` and `copy-dir`. A small regex finds the `<dependency>` blocks for `org.clojure/clojure` and `org.clojure/clojurescript` and injects `<scope>provided</scope>` before the closing `</dependency>` tag. Throws if the format unexpectedly changes (so we notice on the next tools.build bump rather than silently regressing).

No version bump — 0.3.0 is already tagged and the deploy hadn't yet completed (awaiting Clojars secrets). The next release (0.3.1 or whatever) picks this up.

## Test plan

- [x] `clojure -T:build jar` succeeds locally.
- [x] `unzip -p target/de-dupe-0.3.0.jar META-INF/maven/day8/de-dupe/pom.xml | grep -B 1 -A 1 scope` shows `<scope>provided</scope>` on both Clojure entries:
  ```
  <version>1.12.4</version>
  <scope>provided</scope>
  </dependency>
  --
  <version>1.11.132</version>
  <scope>provided</scope>
  </dependency>
  ```